### PR TITLE
style: :art: prettify buttons on landing page; simplify layout

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -1,25 +1,23 @@
 ---
-title: "SDCA's Project Database"
-image: images/data-extraction-storyset.svg
-about:
-  id: hero-heading
-  template: jolla
-  image-width: 40em
-  image-shape: rectangle
-  image-title: Image from Storyset
-  image-alt: An illustration of a computer screen displaying various data charts, surrounded by servers, folders, and additional charts.
-  links:
-    - text: "Getting started"
-      href: https://steno-aarhus.github.io/registers-project-database/getting-started/index.html
-    - text: "Statistics Denmark (DST)"
-      href: https://steno-aarhus.github.io/registers-project-database/dst/index.html
-    - text: "Danish Health Data Authority (DHDA)"
-      href: https://steno-aarhus.github.io/registers-project-database/sds/index.html
-    - text: "How to work with data"
-      href: https://steno-aarhus.github.io/registers-project-database/how-to-work-with-data/index.html
+toc: false
 ---
 
-:::{#hero-heading}
+::: {.text-center}
+# SDCA's Registers Project Database
+
+![](images/data-extraction-storyset.svg){fig-alt="An illustration of a computer screen displaying various data charts, surrounded by servers, folders, and additional charts." width="40em"}
+
+[Getting
+started](https://steno-aarhus.github.io/registers-project-database/getting-started/index.html){.btn
+.btn-primary role="button"} [How to work with
+data](https://steno-aarhus.github.io/registers-project-database/how-to-work-with-data/index.html){.btn
+.btn-primary role="button"}
+
+[Statistics
+Denmark (DST)](https://steno-aarhus.github.io/registers-project-database/dst/index.html){.btn
+.btn-primary role="button"} [Danish Health Data
+Authority (DHDA)](https://steno-aarhus.github.io/registers-project-database/sds/index.html){.btn
+.btn-primary role="button"}
 :::
 
 Image from [Storyset](https://www.storyset.com)


### PR DESCRIPTION
Hej @MarieFrydendahl 

Jeg kom lige forbi projektdatabase-hjemmesiden og tænkte, at jeg hurtigt ville forsøge at gøre landingssiden lidt pænere. 

Med disse ændringer vil den se således ud i stedet: 

<img width="909" height="789" alt="image" src="https://github.com/user-attachments/assets/c1fc4d56-0a78-4937-ab65-6ad1d1e71a56" />


Pt ser den således ud:

<img width="846" height="714" alt="image" src="https://github.com/user-attachments/assets/b71f89dc-d272-4c8a-b7d9-c1333026af69" />

Skriv gerne nedenfor, om du bedre kan lide det nye layout med de røde knapper. Hvis ikke, lukker jeg bare denne PR igen :) 

